### PR TITLE
Android expt:added fragment support, plus included clean up/restruture

### DIFF
--- a/Source/ui_android/java/com/virtualapplications/play/All_Games_Fragment.java
+++ b/Source/ui_android/java/com/virtualapplications/play/All_Games_Fragment.java
@@ -1,0 +1,426 @@
+package com.virtualapplications.play;
+
+import android.app.Activity;
+import android.app.AlertDialog;
+import android.app.ProgressDialog;
+import android.app.UiModeManager;
+import android.content.Context;
+import android.content.DialogInterface;
+import android.content.Intent;
+import android.content.SharedPreferences;
+import android.content.pm.ApplicationInfo;
+import android.content.res.Configuration;
+import android.net.Uri;
+import android.os.AsyncTask;
+import android.os.Build;
+import android.os.Bundle;
+import android.app.Fragment;
+import android.os.Environment;
+import android.util.DisplayMetrics;
+import android.view.Gravity;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.TableLayout;
+import android.widget.TableRow;
+import android.widget.TextView;
+
+import com.android.util.FileUtils;
+import com.virtualapplications.play.database.GameInfo;
+import com.virtualapplications.play.database.SqliteHelper;
+
+import org.apache.commons.lang3.StringUtils;
+
+import java.io.File;
+import java.io.FilenameFilter;
+import java.io.InputStream;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Locale;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+
+import android.content.Context.*;
+
+/**
+ * A simple {@link Fragment} subclass.
+ * Activities that contain this fragment must implement the
+ * Use the {@link All_Games_Fragment#newInstance} factory method to
+ * create an instance of this fragment.
+ */
+public class All_Games_Fragment extends Fragment {
+    // TODO: Rename parameter arguments, choose names that match
+    // the fragment initialization parameters, e.g. ARG_ITEM_NUMBER
+    private static final String ARG_PARAM1 = "param1";
+    private static final String ARG_PARAM2 = "param2";
+
+    // TODO: Rename and change types of parameters
+    private String mParam1;
+    private String mParam2;
+    private TableLayout gameListing;
+    private static boolean isConfigured = false;
+    private int numColumn = 0;
+    private float localScale;
+    private GameInfo gameInfo;
+
+    /**
+     * Use this factory method to create a new instance of
+     * this fragment using the provided parameters.
+     *
+     * @param param1 Parameter 1.
+     * @param param2 Parameter 2.
+     * @return A new instance of fragment all_games.
+     */
+    // TODO: Rename and change types and number of parameters
+    public static All_Games_Fragment newInstance(String param1, String param2) {
+        All_Games_Fragment fragment = new All_Games_Fragment();
+        Bundle args = new Bundle();
+        args.putString(ARG_PARAM1, param1);
+        args.putString(ARG_PARAM2, param2);
+        fragment.setArguments(args);
+        return fragment;
+    }
+
+    public All_Games_Fragment() {
+        // Required empty public constructor
+    }
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        if (getArguments() != null) {
+            mParam1 = getArguments().getString(ARG_PARAM1);
+            mParam2 = getArguments().getString(ARG_PARAM2);
+        }
+    }
+
+    @Override
+    public View onCreateView(LayoutInflater inflater, ViewGroup container,
+                             Bundle savedInstanceState) {
+        // Inflate the layout for this fragment
+
+
+        return inflater.inflate(R.layout.fragment_all_games, container, false);
+    }
+
+    @Override
+    public void onStart(){
+        super.onStart();
+        gameInfo = new GameInfo(this.getActivity());
+        getActivity().getContentResolver().call(SqliteHelper.Games.GAMES_URI, "importDb", null, null);
+        prepareFileListView();
+    }
+
+    @Override
+    public void onAttach(Activity activity) {
+        super.onAttach(activity);
+    }
+
+    @Override
+    public void onDetach() {
+        super.onDetach();
+    }
+
+
+    private String getCurrentDirectory() {
+
+        return MainActivity._preferences.getString(MainActivity.PREFERENCE_CURRENT_DIRECTORY, Environment.getExternalStorageDirectory().getAbsolutePath());
+    }
+
+    private void setCurrentDirectory(String currentDirectory) {
+        SharedPreferences.Editor preferencesEditor = MainActivity._preferences.edit();
+        preferencesEditor.putString(MainActivity.PREFERENCE_CURRENT_DIRECTORY, currentDirectory);
+        preferencesEditor.commit();
+    }
+
+    public static HashSet<String> getExternalMounts() {
+        final HashSet<String> out = new HashSet<String>();
+        String reg = "(?i).*vold.*(vfat|ntfs|exfat|fat32|ext3|ext4|fuse).*rw.*";
+        String s = "";
+        try {
+            final java.lang.Process process = new ProcessBuilder().command("mount")
+                    .redirectErrorStream(true).start();
+            process.waitFor();
+            final InputStream is = process.getInputStream();
+            final byte[] buffer = new byte[1024];
+            while (is.read(buffer) != -1) {
+                s = s + new String(buffer);
+            }
+            is.close();
+        } catch (final Exception e) {
+
+        }
+
+        final String[] lines = s.split("\n");
+        for (String line : lines) {
+            if (StringUtils.containsIgnoreCase(line, "secure"))
+                continue;
+            if (StringUtils.containsIgnoreCase(line, "asec"))
+                continue;
+            if (line.matches(reg)) {
+                String[] parts = line.split(" ");
+                for (String part : parts) {
+                    if (part.startsWith("/"))
+                        if (!StringUtils.containsIgnoreCase(part, "vold"))
+                            out.add(part);
+                }
+            }
+        }
+        return out;
+    }
+
+
+    private static void clearCurrentDirectory() {
+        SharedPreferences.Editor preferencesEditor = MainActivity._preferences.edit();
+        preferencesEditor.remove(MainActivity.PREFERENCE_CURRENT_DIRECTORY);
+        preferencesEditor.commit();
+    }
+
+    public static void resetDirectory() {
+        All_Games_Fragment.clearCurrentDirectory();
+        All_Games_Fragment.isConfigured = false;
+        //All_Games_Fragment.prepareFileListView();
+    }
+
+    private final class ImageFinder extends AsyncTask<String, Integer, List<File>> {
+
+        private int array;
+        private ProgressDialog progDialog;
+
+        public ImageFinder(int arrayType) {
+            this.array = arrayType;
+        }
+
+        private List<File> getFileList(String path) {
+            File storage = new File(path);
+
+            String[] mediaTypes = getResources().getStringArray(array);
+            FilenameFilter[] filter = new FilenameFilter[mediaTypes.length];
+
+            int i = 0;
+            for (final String type : mediaTypes) {
+                filter[i] = new FilenameFilter() {
+
+                    public boolean accept(File dir, String name) {
+                        if (dir.getName().startsWith(".") || name.startsWith(".")) {
+                            return false;
+                        } else if (StringUtils.endsWithIgnoreCase(name, "." + type)) {
+                            File disk = new File(dir, name);
+                            String serial = gameInfo.getSerial(disk);
+                            return MainActivity.IsLoadableExecutableFileName(disk.getPath()) ||
+                                    (serial != null && !serial.equals(""));
+                        } else {
+                            return false;
+                        }
+                    }
+
+                };
+                i++;
+            }
+            FileUtils fileUtils = new FileUtils();
+            Collection<File> files = fileUtils.listFiles(storage, filter, -1);
+            return (List<File>) files;
+        }
+
+        private View createListItem(final File game, final int index) {
+
+            if (!isConfigured) {
+
+                final View childview = getActivity().getLayoutInflater().inflate(
+                        R.layout.file_list_item, null, false);
+
+                ((TextView) childview.findViewById(R.id.game_text)).setText(game.getName());
+
+                childview.findViewById(R.id.childview).setOnClickListener(new View.OnClickListener() {
+                    public void onClick(View view) {
+                        setCurrentDirectory(game.getPath().substring(0,
+                                game.getPath().lastIndexOf(File.separator)));
+                        isConfigured = true;
+                        prepareFileListView();
+                        return;
+                    }
+                });
+
+                return childview;
+            }
+
+            final View childview = getActivity().getLayoutInflater().inflate(
+                    R.layout.game_list_item, null, false);
+
+            ((TextView) childview.findViewById(R.id.game_text)).setText(game.getName());
+
+            final String[] gameStats = gameInfo.getGameInfo(game, childview);
+
+            if (gameStats != null) {
+                childview.findViewById(R.id.childview).setOnLongClickListener(
+                        gameInfo.configureLongClick(gameStats[1], gameStats[2], game));
+
+                if (!gameStats[3].equals("404")) {
+                    gameInfo.getImage(gameStats[0], childview, gameStats[3]);
+                    ((TextView) childview.findViewById(R.id.game_text)).setVisibility(View.GONE);
+                }
+            }
+
+            childview.findViewById(R.id.childview).setOnClickListener(new View.OnClickListener() {
+                public void onClick(View view) {
+                    launchDisk(game);
+                    return;
+                }
+            });
+            return childview;
+        }
+
+        protected void onPreExecute() {
+            progDialog = ProgressDialog.show(getActivity(),
+                    getString(R.string.search_games),
+                    getString(R.string.search_games_msg), true);
+        }
+
+        @Override
+        protected List<File> doInBackground(String... paths) {
+
+            final String root_path = paths[0];
+            ArrayList<File> files = new ArrayList<File>();
+            files.addAll(getFileList(root_path));
+
+            if (!isConfigured) {
+                HashSet<String> extStorage = getExternalMounts();
+                if (extStorage != null && !extStorage.isEmpty()) {
+                    for (Iterator<String> sd = extStorage.iterator(); sd.hasNext();) {
+                        String sdCardPath = sd.next().replace("mnt/media_rw", "storage");
+                        if (!sdCardPath.equals(root_path)) {
+                            if (new File(sdCardPath).canRead()) {
+                                files.addAll(getFileList(sdCardPath));
+                            }
+                        }
+                    }
+                }
+            }
+            return (List<File>) files;
+        }
+
+        @Override
+        protected void onPostExecute(List<File> images) {
+            if (progDialog != null && progDialog.isShowing()) {
+                progDialog.dismiss();
+            }
+            if (images != null && !images.isEmpty()) {
+                // Create the list of acceptable images
+
+                Collections.sort(images);
+
+                TableRow game_row = new TableRow(getActivity());
+                if (isConfigured) {
+                    game_row.setGravity(Gravity.CENTER);
+                }
+                int pad = (int) (10 * localScale + 0.5f);
+                game_row.setPadding(0, 0, 0, pad);
+
+                if (!isConfigured) {
+                    TableRow.LayoutParams params = new TableRow.LayoutParams(
+                            TableRow.LayoutParams.MATCH_PARENT,
+                            TableRow.LayoutParams.WRAP_CONTENT);
+                    params.gravity = Gravity.CENTER_VERTICAL;
+
+                    for (int i = 0; i < images.size(); i++)
+                    {
+                        game_row.addView(createListItem(images.get(i), i));
+                        gameListing.addView(game_row, params);
+                        game_row = new TableRow(getActivity());
+                        game_row.setPadding(0, 0, 0, pad);
+                    }
+                } else {
+                    TableRow.LayoutParams params = new TableRow.LayoutParams(
+                            TableRow.LayoutParams.WRAP_CONTENT,
+                            TableRow.LayoutParams.WRAP_CONTENT);
+                    params.gravity = Gravity.CENTER;
+
+                    int column = 0;
+                    for (int i = 0; i < images.size(); i++)
+                    {
+                        if (column == numColumn)
+                        {
+                            gameListing.addView(game_row, params);
+                            column = 0;
+                            game_row = new TableRow(getActivity());
+                            game_row.setGravity(Gravity.CENTER);
+                            game_row.setPadding(0, 0, 0, pad);
+                        }
+                        game_row.addView(createListItem(images.get(i), i));
+                        column ++;
+                    }
+                    if (column != 0) {
+                        gameListing.addView(game_row, params);
+                    }
+                }
+                gameListing.invalidate();
+            } else {
+                // Display warning that no disks exist
+            }
+        }
+    }
+
+    public void launchDisk(File game) {
+        setCurrentDirectory(game.getPath().substring(0, game.getPath().lastIndexOf(File.separator)));
+        MainActivity.launchDisk(game, getActivity());
+    }
+
+
+    private boolean isAndroidTV(Context context) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.ICE_CREAM_SANDWICH) {
+            UiModeManager uiModeManager = (UiModeManager)
+                    context.getSystemService(Context.UI_MODE_SERVICE);
+            if (uiModeManager.getCurrentModeType() == Configuration.UI_MODE_TYPE_TELEVISION) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private void prepareFileListView() {
+        if (gameInfo == null) {
+            gameInfo = new GameInfo(this.getActivity());
+        }
+
+        gameListing = (TableLayout) getActivity().findViewById(R.id.game_grid);
+        if (gameListing != null) {
+            gameListing.removeAllViews();
+        }
+
+        DisplayMetrics metrics = new DisplayMetrics();
+        getActivity().getWindowManager().getDefaultDisplay().getMetrics(metrics);
+        localScale = getResources().getDisplayMetrics().density;
+        int screenWidth = (int) (metrics.widthPixels * localScale + 0.5f);
+        int screenHeight = (int) (metrics.heightPixels * localScale + 0.5f);
+
+        if (screenWidth > screenHeight) {
+            numColumn = 3;
+        } else {
+            numColumn = 2;
+        }
+
+        if (isAndroidTV(getActivity())) {
+            numColumn += 1;
+        }
+
+        String sdcard = getCurrentDirectory();
+        if (!sdcard.equals(Environment.getExternalStorageDirectory().getAbsolutePath())) {
+            isConfigured = true;
+        }
+
+        new ImageFinder(R.array.disks).execute(sdcard);
+
+		/*if (!mDrawerLayout.isDrawerOpen(Gravity.LEFT)) {
+			if (!isConfigured) {
+				getActionBar().setTitle(getString(R.string.menu_title_look));
+			} else {
+				getActionBar().setTitle(getString(R.string.menu_title_shut));
+			}
+		}*/
+    }
+}

--- a/Source/ui_android/java/com/virtualapplications/play/All_Games_Fragment.java
+++ b/Source/ui_android/java/com/virtualapplications/play/All_Games_Fragment.java
@@ -21,6 +21,7 @@ import android.view.Gravity;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.GridView;
 import android.widget.TableLayout;
 import android.widget.TableRow;
 import android.widget.TextView;
@@ -62,7 +63,6 @@ public class All_Games_Fragment extends Fragment {
     // TODO: Rename and change types of parameters
     private String mParam1;
     private String mParam2;
-    private TableLayout gameListing;
     private static boolean isConfigured = false;
     private int numColumn = 0;
     private float localScale;
@@ -191,8 +191,10 @@ public class All_Games_Fragment extends Fragment {
 
         private int array;
         private ProgressDialog progDialog;
+        private Activity mContext;
 
-        public ImageFinder(int arrayType) {
+        public ImageFinder(int arrayType, Activity context) {
+            this.mContext = context;
             this.array = arrayType;
         }
 
@@ -212,6 +214,8 @@ public class All_Games_Fragment extends Fragment {
                         } else if (StringUtils.endsWithIgnoreCase(name, "." + type)) {
                             File disk = new File(dir, name);
                             String serial = gameInfo.getSerial(disk);
+                            //if(MainActivity.IsLoadableExecutableFileName(disk.getPath()))
+                                //setCurrentDirectory(dir.getAbsolutePath());
                             return MainActivity.IsLoadableExecutableFileName(disk.getPath()) ||
                                     (serial != null && !serial.equals(""));
                         } else {
@@ -227,7 +231,7 @@ public class All_Games_Fragment extends Fragment {
             return (List<File>) files;
         }
 
-        private View createListItem(final File game, final int index) {
+        private View createListkItem(final File game, final int index) {
 
             if (!isConfigured) {
 
@@ -254,14 +258,14 @@ public class All_Games_Fragment extends Fragment {
 
             ((TextView) childview.findViewById(R.id.game_text)).setText(game.getName());
 
-            final String[] gameStats = gameInfo.getGameInfo(game, childview);
+            final String[] gameStats = gameInfo.getGameInfo(game);
 
             if (gameStats != null) {
                 childview.findViewById(R.id.childview).setOnLongClickListener(
                         gameInfo.configureLongClick(gameStats[1], gameStats[2], game));
 
                 if (!gameStats[3].equals("404")) {
-                    gameInfo.getImage(gameStats[0], childview, gameStats[3]);
+                    gameInfo.getImage(gameStats[0], gameStats[3]);
                     ((TextView) childview.findViewById(R.id.game_text)).setVisibility(View.GONE);
                 }
             }
@@ -314,51 +318,17 @@ public class All_Games_Fragment extends Fragment {
 
                 Collections.sort(images);
 
-                TableRow game_row = new TableRow(getActivity());
-                if (isConfigured) {
-                    game_row.setGravity(Gravity.CENTER);
-                }
-                int pad = (int) (10 * localScale + 0.5f);
-                game_row.setPadding(0, 0, 0, pad);
 
                 if (!isConfigured) {
-                    TableRow.LayoutParams params = new TableRow.LayoutParams(
-                            TableRow.LayoutParams.MATCH_PARENT,
-                            TableRow.LayoutParams.WRAP_CONTENT);
-                    params.gravity = Gravity.CENTER_VERTICAL;
-
-                    for (int i = 0; i < images.size(); i++)
-                    {
-                        game_row.addView(createListItem(images.get(i), i));
-                        gameListing.addView(game_row, params);
-                        game_row = new TableRow(getActivity());
-                        game_row.setPadding(0, 0, 0, pad);
-                    }
+                    CoverAdapter CV = new CoverAdapter(mContext, images);
+                    GridView gv = (GridView) mContext.findViewById(R.id.gridview);
+                    //gv.setColumnWidth(300);
+                    gv.setAdapter(CV);
                 } else {
-                    TableRow.LayoutParams params = new TableRow.LayoutParams(
-                            TableRow.LayoutParams.WRAP_CONTENT,
-                            TableRow.LayoutParams.WRAP_CONTENT);
-                    params.gravity = Gravity.CENTER;
-
-                    int column = 0;
-                    for (int i = 0; i < images.size(); i++)
-                    {
-                        if (column == numColumn)
-                        {
-                            gameListing.addView(game_row, params);
-                            column = 0;
-                            game_row = new TableRow(getActivity());
-                            game_row.setGravity(Gravity.CENTER);
-                            game_row.setPadding(0, 0, 0, pad);
-                        }
-                        game_row.addView(createListItem(images.get(i), i));
-                        column ++;
-                    }
-                    if (column != 0) {
-                        gameListing.addView(game_row, params);
-                    }
+                    CoverAdapter CV = new CoverAdapter(mContext, images);
+                    GridView gv = (GridView) mContext.findViewById(R.id.gridview);
+                    gv.setAdapter(CV);
                 }
-                gameListing.invalidate();
             } else {
                 // Display warning that no disks exist
             }
@@ -387,10 +357,6 @@ public class All_Games_Fragment extends Fragment {
             gameInfo = new GameInfo(this.getActivity());
         }
 
-        gameListing = (TableLayout) getActivity().findViewById(R.id.game_grid);
-        if (gameListing != null) {
-            gameListing.removeAllViews();
-        }
 
         DisplayMetrics metrics = new DisplayMetrics();
         getActivity().getWindowManager().getDefaultDisplay().getMetrics(metrics);
@@ -413,7 +379,7 @@ public class All_Games_Fragment extends Fragment {
             isConfigured = true;
         }
 
-        new ImageFinder(R.array.disks).execute(sdcard);
+        new ImageFinder(R.array.disks, getActivity()).execute(sdcard);
 
 		/*if (!mDrawerLayout.isDrawerOpen(Gravity.LEFT)) {
 			if (!isConfigured) {

--- a/Source/ui_android/java/com/virtualapplications/play/CoverAdapter.java
+++ b/Source/ui_android/java/com/virtualapplications/play/CoverAdapter.java
@@ -1,0 +1,83 @@
+package com.virtualapplications.play;
+
+import android.content.ContentResolver;
+import android.content.Context;
+import android.database.Cursor;
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
+import android.os.AsyncTask;
+import android.util.Log;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.BaseAdapter;
+import android.widget.GridView;
+import android.widget.ImageView;
+import android.widget.TextView;
+
+import com.virtualapplications.play.database.GameInfo;
+import com.virtualapplications.play.database.GamesDbAPI;
+import com.virtualapplications.play.database.SqliteHelper;
+
+import org.w3c.dom.Document;
+
+import java.io.File;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.ExecutionException;
+
+/**
+ * Created by alawi on 8/4/15.
+ */
+public class CoverAdapter extends BaseAdapter {
+    private final List<File> mImages;
+    private Context mContext;
+
+        public CoverAdapter(Context c,List<File> images) {
+            mContext = c;
+            mImages = images;
+        }
+
+    public int getCount() {
+        //return mThumbIds.length;
+        return mImages.size();
+    }
+
+    public Object getItem(int position) {
+        return null;
+    }
+
+    public long getItemId(int position) {
+        return position;
+    }
+
+    // create a new ImageView for each item referenced by the Adapter
+    public View getView(int position, View convertView, ViewGroup parent) {
+        ImageView imageView;
+        if (convertView == null) {
+            // if it's not recycled, initialize some attributes
+            imageView = new ImageView(mContext);
+            imageView.setLayoutParams(new GridView.LayoutParams(300, 400));
+            imageView.setScaleType(ImageView.ScaleType.CENTER_CROP);
+            imageView.setPadding(8, 8, 8, 8);
+        } else {
+            imageView = (ImageView) convertView;
+        }
+        GameInfo gameInfo = null;
+        if (gameInfo == null) {
+            gameInfo = new GameInfo(mContext);
+        }
+        String[] st = gameInfo.getGameInfo(mImages.get(position));
+
+        if (st != null){
+            Bitmap bt = gameInfo.getImage(st[0],st[3]);
+            if (bt != null)
+                imageView.setImageBitmap(bt);
+        } else {
+            imageView.setImageResource(R.drawable.boxart);
+        }
+
+        return imageView;
+    }
+
+}
+

--- a/Source/ui_android/java/com/virtualapplications/play/ExternalEmulatorLauncher.java
+++ b/Source/ui_android/java/com/virtualapplications/play/ExternalEmulatorLauncher.java
@@ -1,0 +1,35 @@
+package com.virtualapplications.play;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.os.Bundle;
+import android.os.Environment;
+
+import java.io.File;
+
+public class ExternalEmulatorLauncher extends Activity {
+    public ExternalEmulatorLauncher() {
+    }
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        // TODO: This method is called when the BroadcastReceiver is receiving
+        // an Intent broadcast.
+        NativeInterop.setFilesDirPath(Environment.getExternalStorageDirectory().getAbsolutePath());
+
+        EmulatorActivity.RegisterPreferences();
+
+        if(!NativeInterop.isVirtualMachineCreated())
+        {
+            NativeInterop.createVirtualMachine();
+        }
+        Intent intent = getIntent();
+        if (intent.getAction() != null) {
+            if (intent.getAction().equals(Intent.ACTION_VIEW)) {
+                MainActivity.launchDisk(new File(intent.getData().getPath()), this);
+            }
+        }
+        finish();
+    }
+}

--- a/Source/ui_android/java/com/virtualapplications/play/MainActivity.java
+++ b/Source/ui_android/java/com/virtualapplications/play/MainActivity.java
@@ -42,20 +42,14 @@ import com.virtualapplications.play.database.SqliteHelper.Games;
 
 public class MainActivity extends ActionBarActivity implements NavigationDrawerFragment.NavigationDrawerCallbacks
 {	
-	private static final String PREFERENCE_CURRENT_DIRECTORY = "CurrentDirectory";
-	
-	private SharedPreferences _preferences;
-	private TableLayout gameListing;
-	static Activity mActivity;
-	private boolean isConfigured = false;
-	private int numColumn = 0;
-	private DrawerLayout mDrawerLayout;
-	private ActionBarDrawerToggle mDrawerToggle;
-	private float localScale;
+
+
+
 	private int currentOrientation;
-	private GameInfo gameInfo;
 	protected NavigationDrawerFragment mNavigationDrawerFragment;
-	private boolean doubleBackToExitPressedOnce;
+	static Activity mActivity;
+	static SharedPreferences _preferences;
+	static final String PREFERENCE_CURRENT_DIRECTORY = "CurrentDirectory";
 
 	@Override 
 	protected void onCreate(Bundle savedInstanceState) 
@@ -69,7 +63,7 @@ public class MainActivity extends ActionBarActivity implements NavigationDrawerF
 		} else {
 			setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_SENSOR_PORTRAIT);
 		}
-		
+
 		setContentView(R.layout.main);
 
 		Toolbar toolbar = (Toolbar) findViewById(R.id.my_awesome_toolbar);
@@ -97,13 +91,10 @@ public class MainActivity extends ActionBarActivity implements NavigationDrawerF
 	}
 
 	@Override 
-	protected void onPostCreate(Bundle savedInstanceState) 
-	{	
+	protected void onPostCreate(Bundle savedInstanceState) {
 		super.onPostCreate(savedInstanceState);
-		
 
-		adjustUI();
-		
+
 		NativeInterop.setFilesDirPath(Environment.getExternalStorageDirectory().getAbsolutePath());
 
 		_preferences = getSharedPreferences("prefs", MODE_PRIVATE);
@@ -114,13 +105,16 @@ public class MainActivity extends ActionBarActivity implements NavigationDrawerF
 			NativeInterop.createVirtualMachine();
 		}
 
-		gameInfo = new GameInfo(MainActivity.this);
-		getContentResolver().call(Games.GAMES_URI, "importDb", null, null);
+		adjustUI();
 
-		prepareFileListView();
+
+		FragmentTransaction ft = getFragmentManager().beginTransaction();
+		ft.replace(R.id.content_frame, new All_Games_Fragment().newInstance(null, null));
+		ft.commit();
+
 	}
 
-	public int getStatusBarHeight() {
+	int getStatusBarHeight() {
 		int result = 0;
 		int resourceId = getResources().getIdentifier("status_bar_height", "dimen", "android");
 		if (resourceId > 0) {
@@ -129,7 +123,7 @@ public class MainActivity extends ActionBarActivity implements NavigationDrawerF
 		return result;
 	}
 
-	private void adjustUI() {
+	void adjustUI() {
 		//this sets toolbar margin, but in effect moving the DrawerLayout
 		int statusBarHeight = getStatusBarHeight();
 
@@ -184,7 +178,7 @@ public class MainActivity extends ActionBarActivity implements NavigationDrawerF
 				navigation_drawer.getPaddingBottom() + p.y);
 
 		View game_scroller = findViewById(R.id.game_grid);
-		game_scroller.setPadding(
+			game_scroller.setPadding(
 			game_scroller.getPaddingLeft(), 
 			game_scroller.getPaddingTop(), 
 			game_scroller.getPaddingRight(), 
@@ -192,13 +186,13 @@ public class MainActivity extends ActionBarActivity implements NavigationDrawerF
 		}
 	}
 
-	public static Point getNavigationBarSize(Context context) {
+	static Point getNavigationBarSize(Context context) {
 		Point appUsableSize = getAppUsableScreenSize(context);
 		Point realScreenSize = getRealScreenSize(context);
 		return new Point(realScreenSize.x - appUsableSize.x, realScreenSize.y - appUsableSize.y);
 	}
 
-	public static Point getAppUsableScreenSize(Context context) {
+	static Point getAppUsableScreenSize(Context context) {
 		WindowManager windowManager = (WindowManager) context.getSystemService(Context.WINDOW_SERVICE);
 		Display display = windowManager.getDefaultDisplay();
 		Point size = new Point();
@@ -206,7 +200,7 @@ public class MainActivity extends ActionBarActivity implements NavigationDrawerF
 		return size;
 	}
 
-	public static Point getRealScreenSize(Context context) {
+	static Point getRealScreenSize(Context context) {
 		WindowManager windowManager = (WindowManager) context.getSystemService(Context.WINDOW_SERVICE);
 		Display display = windowManager.getDefaultDisplay();
 		Point size = new Point();
@@ -223,8 +217,40 @@ public class MainActivity extends ActionBarActivity implements NavigationDrawerF
 		return size;
 	}
 
-	private static long getBuildDate(Context context) 
-	{
+	private void displaySettingsActivity() {
+		Intent intent = new Intent(getApplicationContext(), SettingsActivity.class);
+		startActivity(intent);
+	}
+
+	private void displayAboutDialog() {
+		long buildDate = getBuildDate(this);
+		String buildDateString = new SimpleDateFormat("yyyy/MM/dd", Locale.getDefault()).format(buildDate);
+		String aboutMessage = String.format("Build Date: %s", buildDateString);
+		displaySimpleMessage("About Play!", aboutMessage, this);
+	}
+
+	static void displaySimpleMessage(String title, String message, Context context) {
+		AlertDialog.Builder builder = new AlertDialog.Builder(context);
+
+		builder.setTitle(title);
+		builder.setMessage(message);
+
+		builder.setPositiveButton("OK",
+				new DialogInterface.OnClickListener()
+				{
+					@Override
+					public void onClick(DialogInterface dialog, int id)
+					{
+
+					}
+				}
+		);
+
+		AlertDialog dialog = builder.create();
+		dialog.show();
+	}
+
+	static long getBuildDate(Context context)  {
 		try
 		{
 			ApplicationInfo ai = context.getPackageManager().getApplicationInfo(context.getPackageName(), 0);
@@ -232,164 +258,12 @@ public class MainActivity extends ActionBarActivity implements NavigationDrawerF
 			ZipEntry ze = zf.getEntry("classes.dex");
 			long time = ze.getTime();
 			return time;
-		} 
-		catch (Exception e) 
+		}
+		catch (Exception e)
 		{
 
 		}
 		return 0;
-	}
-	
-	private void displaySimpleMessage(String title, String message)
-	{
-		AlertDialog.Builder builder = new AlertDialog.Builder(this);
-
-		builder.setTitle(title);
-		builder.setMessage(message);
-
-		builder.setPositiveButton("OK", 
-			new DialogInterface.OnClickListener() 
-			{
-				@Override
-				public void onClick(DialogInterface dialog, int id) 
-				{
-					
-				}
-			}
-		);
-		
-		AlertDialog dialog = builder.create();
-		dialog.show();
-	}
-	
-	private void displaySettingsActivity()
-	{
-		Intent intent = new Intent(getApplicationContext(), SettingsActivity.class);
-		startActivity(intent);
-	}
-	
-	private void displayAboutDialog()
-	{
-		long buildDate = getBuildDate(this);
-		String buildDateString = new SimpleDateFormat("yyyy/MM/dd", Locale.getDefault()).format(buildDate);
-		String aboutMessage = String.format("Build Date: %s", buildDateString);
-		displaySimpleMessage("About Play!", aboutMessage);
-	}
-	
-
-	
-	@Override
-	public void onConfigurationChanged(Configuration newConfig) {
-		super.onConfigurationChanged(newConfig);
-		mNavigationDrawerFragment.onConfigurationChanged(newConfig);
-		
-	}
-	
-	private String getCurrentDirectory()
-	{
-		return _preferences.getString(PREFERENCE_CURRENT_DIRECTORY, Environment.getExternalStorageDirectory().getAbsolutePath());
-	}
-	
-	public static HashSet<String> getExternalMounts() {
-		final HashSet<String> out = new HashSet<String>();
-		String reg = "(?i).*vold.*(vfat|ntfs|exfat|fat32|ext3|ext4|fuse).*rw.*";
-		String s = "";
-		try {
-			final java.lang.Process process = new ProcessBuilder().command("mount")
-			.redirectErrorStream(true).start();
-			process.waitFor();
-			final InputStream is = process.getInputStream();
-			final byte[] buffer = new byte[1024];
-			while (is.read(buffer) != -1) {
-				s = s + new String(buffer);
-			}
-			is.close();
-		} catch (final Exception e) {
-			
-		}
-		
-		final String[] lines = s.split("\n");
-		for (String line : lines) {
-			if (StringUtils.containsIgnoreCase(line, "secure"))
-				continue;
-			if (StringUtils.containsIgnoreCase(line, "asec"))
-				continue;
-			if (line.matches(reg)) {
-				String[] parts = line.split(" ");
-				for (String part : parts) {
-					if (part.startsWith("/"))
-						if (!StringUtils.containsIgnoreCase(part, "vold"))
-							out.add(part);
-				}
-			}
-		}
-		return out;
-	}
-	
-	private void setCurrentDirectory(String currentDirectory)
-	{
-		SharedPreferences.Editor preferencesEditor = _preferences.edit();
-		preferencesEditor.putString(PREFERENCE_CURRENT_DIRECTORY, currentDirectory);
-		preferencesEditor.commit();
-	}
-	
-	private void clearCurrentDirectory()
-	{
-		SharedPreferences.Editor preferencesEditor = _preferences.edit();
-		preferencesEditor.remove(PREFERENCE_CURRENT_DIRECTORY);
-		preferencesEditor.commit();
-	}
-	
-	public static void resetDirectory() {
-		((MainActivity) mActivity).clearCurrentDirectory();
-		((MainActivity) mActivity).isConfigured = false;
-		((MainActivity) mActivity).prepareFileListView();
-	}
-	
-	private void clearCoverCache() {
-		File dir = new File(getExternalFilesDir(null), "covers");
-		for (File file : dir.listFiles()) {
-			if (!file.isDirectory()) {
-				file.delete();
-			}
-		}
-	}
-	
-	public static void clearCache() {
-		((MainActivity) mActivity).clearCoverCache();
-	}
-	
-	private static boolean IsLoadableExecutableFileName(String fileName)
-	{
-		return fileName.toLowerCase().endsWith(".elf");
-	}
-	
-	private static boolean IsLoadableDiskImageFileName(String fileName)
-	{
-		
-		return  
-				fileName.toLowerCase().endsWith(".iso") ||
-				fileName.toLowerCase().endsWith(".bin") ||
-				fileName.toLowerCase().endsWith(".cso") ||
-				fileName.toLowerCase().endsWith(".isz");
-	}
-	
-		@Override
-	public void onNavigationDrawerItemSelected(int position) {
-		//This will only manages the top stack, which is currently empty
-	}
-
-	@Override
-	public void onNavigationDrawerBottomItemSelected(int position) {
-		switch (position) {
-			case 0:
-				displaySettingsActivity();
-				break;
-			case 1:
-				displayAboutDialog();
-				break;
-
-		}
 	}
 
 	public void restoreActionBar() {
@@ -400,7 +274,6 @@ public class MainActivity extends ActionBarActivity implements NavigationDrawerF
 		actionBar.setSubtitle(R.string.menu_title_shut);
 	}
 
-	
 	public boolean onCreateOptionsMenu(Menu menu) {
 		if (!mNavigationDrawerFragment.isDrawerOpen()) {
 			// Only show items in the action bar relevant to this screen
@@ -423,189 +296,58 @@ public class MainActivity extends ActionBarActivity implements NavigationDrawerF
 		finish();
 	}
 
-	private final class ImageFinder extends AsyncTask<String, Integer, List<File>> {
-		
-		private int array;
-		private ProgressDialog progDialog;
-		
-		public ImageFinder(int arrayType) {
-			this.array = arrayType;
-		}
-		
-		private List<File> getFileList(String path) {
-			File storage = new File(path);
-			
-			String[] mediaTypes = MainActivity.this.getResources().getStringArray(array);
-			FilenameFilter[] filter = new FilenameFilter[mediaTypes.length];
-			
-			int i = 0;
-			for (final String type : mediaTypes) {
-				filter[i] = new FilenameFilter() {
-					
-					public boolean accept(File dir, String name) {
-						if (dir.getName().startsWith(".") || name.startsWith(".")) {
-							return false;
-						} else if (StringUtils.endsWithIgnoreCase(name, "." + type)) {
-							File disk = new File(dir, name);
-							String serial = gameInfo.getSerial(disk);
-							return IsLoadableExecutableFileName(disk.getPath()) ||
-								(serial != null && !serial.equals(""));
-						} else {
-							return false;
-						}
-					}
-					
-				};
-				i++;
-			}
-			FileUtils fileUtils = new FileUtils();
-			Collection<File> files = fileUtils.listFiles(storage, filter, -1);
-			return (List<File>) files;
-		}
-		
-		private View createListItem(final File game, final int index) {
-			
-			if (!isConfigured) {
-				
-				final View childview = MainActivity.this.getLayoutInflater().inflate(
-					R.layout.file_list_item, null, false);
-				
-				((TextView) childview.findViewById(R.id.game_text)).setText(game.getName());
-				
-				childview.findViewById(R.id.childview).setOnClickListener(new OnClickListener() {
-					public void onClick(View view) {
-						setCurrentDirectory(game.getPath().substring(0,
-							game.getPath().lastIndexOf(File.separator)));
-						isConfigured = true;
-						prepareFileListView();
-						return;
-					}
-				});
-				
-				return childview;
-			}
-			
-			final View childview = MainActivity.this.getLayoutInflater().inflate(
-				R.layout.game_list_item, null, false);
-			
-			((TextView) childview.findViewById(R.id.game_text)).setText(game.getName());
-			
-			final String[] gameStats = gameInfo.getGameInfo(game, childview);
-			
-			if (gameStats != null) {
-				childview.findViewById(R.id.childview).setOnLongClickListener(
-					gameInfo.configureLongClick(gameStats[1], gameStats[2], game));
+	@Override
+	public void onConfigurationChanged(Configuration newConfig) {
+		super.onConfigurationChanged(newConfig);
+		mNavigationDrawerFragment.onConfigurationChanged(newConfig);
 
-				if (!gameStats[3].equals("404")) {
-					gameInfo.getImage(gameStats[0], childview, gameStats[3]);
-					((TextView) childview.findViewById(R.id.game_text)).setVisibility(View.GONE);
-				}
-			}
-			
-			childview.findViewById(R.id.childview).setOnClickListener(new OnClickListener() {
-				public void onClick(View view) {
-					launchDisk(game, false);
-					return;
-				}
-			});
-			return childview;
-		}
-		
-		protected void onPreExecute() {
-			progDialog = ProgressDialog.show(MainActivity.this,
-				getString(R.string.search_games),
-				getString(R.string.search_games_msg), true);
-		}
-		
-		@Override
-		protected List<File> doInBackground(String... paths) {
-			
-			final String root_path = paths[0];
-			ArrayList<File> files = new ArrayList<File>();
-			files.addAll(getFileList(root_path));
-			
-			if (!isConfigured) {
-				HashSet<String> extStorage = MainActivity.getExternalMounts();
-				if (extStorage != null && !extStorage.isEmpty()) {
-					for (Iterator<String> sd = extStorage.iterator(); sd.hasNext();) {
-						String sdCardPath = sd.next().replace("mnt/media_rw", "storage");
-						if (!sdCardPath.equals(root_path)) {
-							if (new File(sdCardPath).canRead()) {
-								files.addAll(getFileList(sdCardPath));
-							}
-						}
-					}
-				}
-			}
-			return (List<File>) files;
-		}
-		
-		@Override
-		protected void onPostExecute(List<File> images) {
-			if (progDialog != null && progDialog.isShowing()) {
-				progDialog.dismiss();
-			}
-			if (images != null && !images.isEmpty()) {
-				// Create the list of acceptable images
+	}
 
-				Collections.sort(images);
-	
-				TableRow game_row = new TableRow(MainActivity.this);
-				if (isConfigured) {
-					game_row.setGravity(Gravity.CENTER);
-				}
-				int pad = (int) (10 * localScale + 0.5f);
-				game_row.setPadding(0, 0, 0, pad);
-				
-				if (!isConfigured) {
-					TableRow.LayoutParams params = new TableRow.LayoutParams(
-						TableRow.LayoutParams.MATCH_PARENT,
-						TableRow.LayoutParams.WRAP_CONTENT);
-					params.gravity = Gravity.CENTER_VERTICAL;
+	@Override
+	public void onNavigationDrawerItemSelected(int position) {
+		//This will only manages the top stack, which is currently empty
+	}
 
-					for (int i = 0; i < images.size(); i++)
-					{
-						game_row.addView(createListItem(images.get(i), i));
-						gameListing.addView(game_row, params);
-						game_row = new TableRow(MainActivity.this);
-						game_row.setPadding(0, 0, 0, pad);
-					}
-				} else {
-					TableRow.LayoutParams params = new TableRow.LayoutParams(
-						TableRow.LayoutParams.WRAP_CONTENT,
-						TableRow.LayoutParams.WRAP_CONTENT);
-					params.gravity = Gravity.CENTER;
+	@Override
+	public void onNavigationDrawerBottomItemSelected(int position) {
+		switch (position) {
+			case 0:
+				displaySettingsActivity();
+				break;
+			case 1:
+				displayAboutDialog();
+				break;
 
-					int column = 0;
-					for (int i = 0; i < images.size(); i++)
-					{
-						if (column == numColumn)
-						{
-							gameListing.addView(game_row, params);
-							column = 0;
-							game_row = new TableRow(MainActivity.this);
-							game_row.setGravity(Gravity.CENTER);
-							game_row.setPadding(0, 0, 0, pad);
-						}
-						game_row.addView(createListItem(images.get(i), i));
-						column ++;
-					}
-					if (column != 0) {
-						gameListing.addView(game_row, params);
-					}
-				}
-				gameListing.invalidate();
-			} else {
-				// Display warning that no disks exist
+		}
+	}
+
+	private void clearCoverCache() {
+		File dir = new File(getExternalFilesDir(null), "covers");
+		for (File file : dir.listFiles()) {
+			if (!file.isDirectory()) {
+				file.delete();
 			}
 		}
 	}
-	
-	public static void launchGame(File game) {
-		((MainActivity) mActivity).launchDisk(game, false);
+
+	static void clearCache() {
+		((MainActivity) mActivity).clearCoverCache();
 	}
-	
-	private void launchDisk (File game, boolean terminate) {
+
+	static boolean IsLoadableExecutableFileName(String fileName) {
+		return fileName.toLowerCase().endsWith(".elf");
+	}
+
+	private static boolean IsLoadableDiskImageFileName(String fileName) {
+
+		return
+				fileName.toLowerCase().endsWith(".iso") ||
+						fileName.toLowerCase().endsWith(".bin") ||
+						fileName.toLowerCase().endsWith(".cso") ||
+						fileName.toLowerCase().endsWith(".isz");
+	}
+
+	public static void launchDisk(File game, Context context) {
 		try
 		{
 			if(IsLoadableExecutableFileName(game.getPath()))
@@ -616,72 +358,16 @@ public class MainActivity extends ActionBarActivity implements NavigationDrawerF
 			{
 				NativeInterop.bootDiskImage(game.getPath());
 			}
-			setCurrentDirectory(game.getPath().substring(0, game.getPath().lastIndexOf(File.separator)));
 		}
 		catch(Exception ex)
 		{
-			displaySimpleMessage("Error", ex.getMessage());
+			MainActivity.displaySimpleMessage("Error", ex.getMessage(), context);
 			return;
 		}
 		//TODO: Catch errors that might happen while loading files
-		Intent intent = new Intent(getApplicationContext(), EmulatorActivity.class);
-		startActivity(intent);
-		if (terminate) {
-			finish();
-		}
-	}
-	
-	private boolean isAndroidTV(Context context) {
-		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.ICE_CREAM_SANDWICH) {
-			UiModeManager uiModeManager = (UiModeManager)
-			context.getSystemService(Context.UI_MODE_SERVICE);
-			if (uiModeManager.getCurrentModeType() == Configuration.UI_MODE_TYPE_TELEVISION) {
-				return true;
-			}
-		}
-		return false;
+		Intent intent = new Intent(context, EmulatorActivity.class);
+		context.startActivity(intent);
 	}
 
-	private void prepareFileListView()
-	{
-		if (gameInfo == null) {
-			gameInfo = new GameInfo(MainActivity.this);
-		}
-		
-		gameListing = (TableLayout) findViewById(R.id.game_grid);
-		if (gameListing != null) {
-			gameListing.removeAllViews();
-		}
-		
-		DisplayMetrics metrics = new DisplayMetrics();
-		getWindowManager().getDefaultDisplay().getMetrics(metrics);
-		localScale = getResources().getDisplayMetrics().density;
-		int screenWidth = (int) (metrics.widthPixels * localScale + 0.5f);
-		int screenHeight = (int) (metrics.heightPixels * localScale + 0.5f);
-		
-		if (screenWidth > screenHeight) {
-			numColumn = 3;
-		} else {
-			numColumn = 2;
-		}
-		
-		if (isAndroidTV(getApplicationContext())) {
-			numColumn += 1;
-		}
-		
-		String sdcard = getCurrentDirectory();
-		if (!sdcard.equals(Environment.getExternalStorageDirectory().getAbsolutePath())) {
-			isConfigured = true;
-		}
-		
-		new ImageFinder(R.array.disks).execute(sdcard);
-		
-		/*if (!mDrawerLayout.isDrawerOpen(Gravity.LEFT)) {
-			if (!isConfigured) {
-				getActionBar().setTitle(getString(R.string.menu_title_look));
-			} else {
-				getActionBar().setTitle(getString(R.string.menu_title_shut));
-			}
-		}*/
-	}
+
 }

--- a/Source/ui_android/java/com/virtualapplications/play/MainActivity.java
+++ b/Source/ui_android/java/com/virtualapplications/play/MainActivity.java
@@ -58,11 +58,7 @@ public class MainActivity extends ActionBarActivity implements NavigationDrawerF
 		//Log.w(Constants.TAG, "MainActivity - onCreate");
 		
 		currentOrientation = getResources().getConfiguration().orientation;
-		if (currentOrientation == Configuration.ORIENTATION_LANDSCAPE) {
-			setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE);
-		} else {
-			setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_SENSOR_PORTRAIT);
-		}
+
 
 		setContentView(R.layout.main);
 
@@ -177,12 +173,13 @@ public class MainActivity extends ActionBarActivity implements NavigationDrawerF
 				navigation_drawer.getPaddingRight(), 
 				navigation_drawer.getPaddingBottom() + p.y);
 
-		View game_scroller = findViewById(R.id.game_grid);
+		/*View game_scroller = findViewById(R.id.game_grid);
 			game_scroller.setPadding(
 			game_scroller.getPaddingLeft(), 
 			game_scroller.getPaddingTop(), 
 			game_scroller.getPaddingRight(), 
 			game_scroller.getPaddingBottom() + p.y);
+		*/
 		}
 	}
 

--- a/Source/ui_android/java/com/virtualapplications/play/SettingsActivity.java
+++ b/Source/ui_android/java/com/virtualapplications/play/SettingsActivity.java
@@ -84,7 +84,7 @@ public class SettingsActivity extends PreferenceActivity
 				button_f.setOnPreferenceClickListener(new Preference.OnPreferenceClickListener() {
 					@Override
 					public boolean onPreferenceClick(Preference arg0) {
-						MainActivity.resetDirectory();
+						All_Games_Fragment.resetDirectory();
 						getPreferenceScreen().removePreference(button_f);
 						return true;
 					}

--- a/Source/ui_android/java/com/virtualapplications/play/database/GameInfo.java
+++ b/Source/ui_android/java/com/virtualapplications/play/database/GameInfo.java
@@ -64,7 +64,7 @@ public class GameInfo {
 		
 	}
 	
-	public Bitmap getImage(String key, View childview, String boxart) {
+	public Bitmap getImage(String key, String boxart) {
 		String path = mContext.getExternalFilesDir(null) + "/covers/";
 		
 		File file = new File(path, key + ".jpg");
@@ -73,35 +73,25 @@ public class GameInfo {
 			BitmapFactory.Options options = new BitmapFactory.Options();
 			options.inPreferredConfig = Bitmap.Config.ARGB_8888;
 			Bitmap bitmap = BitmapFactory.decodeFile(file.getAbsolutePath(), options);
-			if (childview != null) {
-				ImageView preview = (ImageView) childview.findViewById(R.id.game_icon);
-				preview.setImageBitmap(bitmap);
-				preview.setScaleType(ScaleType.CENTER_INSIDE);
-				((TextView) childview.findViewById(R.id.game_text)).setVisibility(View.GONE);
-			}
 			return bitmap;
 		} else {
-			new GameImage(childview, boxart).execute(key);
+			new GameImage(boxart).execute(key);
 			return null;
 		}
 	}
 	
 	public class GameImage extends AsyncTask<String, Integer, Bitmap> {
 		
-		private View childview;
 		private String key;
 		private ImageView preview;
 		private String boxart;
 		
-		public GameImage(View childview, String boxart) {
-			this.childview = childview;
+		public GameImage( String boxart) {
 			this.boxart = boxart;
 		}
 		
 		protected void onPreExecute() {
-			if (childview != null) {
-				preview = (ImageView) childview.findViewById(R.id.game_icon);
-			}
+
 		}
 		
 		private int calculateInSampleSize(BitmapFactory.Options options) {
@@ -179,7 +169,6 @@ public class GameInfo {
 				if (preview != null) {
 					preview.setImageBitmap(image);
 					preview.setScaleType(ScaleType.CENTER_INSIDE);
-					((TextView) childview.findViewById(R.id.game_text)).setVisibility(View.GONE);
 				}
 			}
 		}
@@ -213,18 +202,17 @@ public class GameInfo {
 		};
 	}
 	
-	public String[] getGameInfo(File game, View childview) {
+	public String[] getGameInfo(File game) {
 		String serial = getSerial(game);
 		if (serial == null) {
-			getImage(game.getName(), childview, null);
+			getImage(game.getName(), null);
 			return null;
 		}
 		String suffix = serial.substring(5, serial.length());
 		String gameID = null,  title = null, overview = null, boxart = null;
 		ContentResolver cr = mContext.getContentResolver();
-		String selection = Games.KEY_SERIAL + "=? OR " + Games.KEY_SERIAL + "=? OR " + Games.KEY_SERIAL + "=? OR "
-							+ Games.KEY_SERIAL + "=? OR " + Games.KEY_SERIAL + "=? OR " + Games.KEY_SERIAL + "=?";
-		String[] selectionArgs = { serial, "SLUS" + suffix, "SLES" + suffix, "SLPS" + suffix, "SLPM" + suffix, "SCES" + suffix };
+		String selection = SqliteHelper.Games.KEY_SERIAL + " like ?";
+		String[] selectionArgs = { serial};
 		Cursor c = cr.query(Games.GAMES_URI, null, selection, selectionArgs, null);
 		if (c != null && c.getCount() > 0) {
 			if (c.moveToFirst()) {
@@ -243,9 +231,8 @@ public class GameInfo {
 		if (overview != null && boxart != null &&
 			!overview.equals("") && !boxart.equals("")) {
 			return new String[] { gameID, title, overview, boxart };
-		} else {
+		}  else {
 			GamesDbAPI gameDatabase = new GamesDbAPI(mContext, gameID);
-			gameDatabase.setView(childview);
 			gameDatabase.execute(game);
 			return null;
 		}

--- a/Source/ui_android/java/com/virtualapplications/play/database/GameInfo.java
+++ b/Source/ui_android/java/com/virtualapplications/play/database/GameInfo.java
@@ -203,7 +203,7 @@ public class GameInfo {
 				new DialogInterface.OnClickListener() {
 					public void onClick(DialogInterface dialog, int which) {
 						dialog.dismiss();
-						MainActivity.launchGame(gameFile);
+						MainActivity.launchDisk(gameFile, mContext);
 						return;
 					}
 				});

--- a/Source/ui_android/java/com/virtualapplications/play/database/GamesDbAPI.java
+++ b/Source/ui_android/java/com/virtualapplications/play/database/GamesDbAPI.java
@@ -52,7 +52,6 @@ import com.virtualapplications.play.database.SqliteHelper.Games;
 public class GamesDbAPI extends AsyncTask<File, Integer, Document> {
 
 	private int index;
-	private View childview;
 	private Context mContext;
 	private String gameID;
 	private File gameFile;
@@ -69,9 +68,7 @@ public class GamesDbAPI extends AsyncTask<File, Integer, Document> {
 		this.gameID = gameID;
 	}
 	
-	public void setView(View childview) {
-		this.childview = childview;
-	}
+
 
 	protected void onPreExecute() {
 		gameInfo = new GameInfo(mContext);
@@ -150,13 +147,10 @@ public class GamesDbAPI extends AsyncTask<File, Integer, Document> {
 								String boxart = c.getString(c.getColumnIndex(Games.KEY_BOXART));
 								if (overview != null && boxart != null &&
 									!overview.equals("") && !boxart.equals("")) {
-									if (childview != null) {
-										childview.findViewById(R.id.childview).setOnLongClickListener(
-											gameInfo.configureLongClick(title, overview, gameFile));
 										if (boxart != null) {
-											gameInfo.getImage(dataID, childview, boxart);
+											gameInfo.getImage(dataID, boxart);
 										}
-									}
+
 									break;
 								}
 							} while (c.moveToNext());
@@ -165,7 +159,6 @@ public class GamesDbAPI extends AsyncTask<File, Integer, Document> {
 					c.close();
 					if (dataID == null) {
 						GamesDbAPI gameDatabase = new GamesDbAPI(mContext, remoteID);
-						gameDatabase.setView(childview);
 						gameDatabase.execute(gameFile);
 					}
 				} else {
@@ -203,13 +196,6 @@ public class GamesDbAPI extends AsyncTask<File, Integer, Document> {
 					}
 					c.close();
 
-					if (childview != null) {
-						childview.findViewById(R.id.childview).setOnLongClickListener(
-							gameInfo.configureLongClick(getValue(root, "GameTitle"), overview, gameFile));
-						if (coverImage != null) {
-							gameInfo.getImage(remoteID, childview, coverImage);
-						}
-					}
 				}
 			} catch (Exception e) {
 				
@@ -273,6 +259,10 @@ public class GamesDbAPI extends AsyncTask<File, Integer, Document> {
 			}
 		}
 		return "";
+	}
+
+	public String[] getit(){
+		return gameInfo.getGameInfo(gameFile);
 	}
 
 }

--- a/Source/ui_android/java/com/virtualapplications/play/database/TheGamesDB.java
+++ b/Source/ui_android/java/com/virtualapplications/play/database/TheGamesDB.java
@@ -61,7 +61,7 @@ public class TheGamesDB extends ContentProvider {
 
 		@Override
 		public void onCreate(SQLiteDatabase db) {
-			db.execSQL("CREATE TABLE " + Games.TABLE_NAME + " ("
+			db.execSQL("CREATE TABLE IF NOT EXISTS " + Games.TABLE_NAME + " ("
 					   + Games.TABLE_ID + " INTEGER PRIMARY KEY AUTOINCREMENT,"
 					   + Games.KEY_GAMEID + " VARCHAR(255),"
 					   + Games.KEY_TITLE + " VARCHAR(255),"
@@ -69,7 +69,7 @@ public class TheGamesDB extends ContentProvider {
 					   + Games.KEY_SERIAL + " VARCHAR(255),"
 					   + Games.KEY_BOXART + " VARCHAR(255)"+ ");");
 			
-			db.execSQL("CREATE TABLE " + Covers.TABLE_NAME + " ("
+			db.execSQL("CREATE TABLE IF NOT EXISTS " + Covers.TABLE_NAME + " ("
 					   + Covers.TABLE_ID + " INTEGER PRIMARY KEY AUTOINCREMENT,"
 					   + Covers.KEY_SERIAL + " VARCHAR(255),"
 					   + Covers.KEY_DISK + " VARCHAR(255),"

--- a/build_android/AndroidManifest.xml
+++ b/build_android/AndroidManifest.xml
@@ -28,7 +28,7 @@
 		android:banner="@drawable/ic_banner"
 		android:logo="@drawable/ic_logo"
 		android:isGame="true"
-		android:theme="@style/Blue"
+		android:theme="@style/AppTheme"
 		>
 		<activity 
 			android:name=".MainActivity"
@@ -41,6 +41,26 @@
 				<category android:name="android.intent.category.LEANBACK_LAUNCHER" />
 				<category android:name="android.intent.category.LAUNCHER" />
 			</intent-filter>
+		</activity>
+		<activity
+			android:name=".EmulatorActivity"
+			android:configChanges="orientation|locale|keyboard|keyboardHidden|navigation"
+			android:screenOrientation="sensorLandscape"
+			android:theme="@android:style/Theme.NoTitleBar.Fullscreen">
+		</activity>
+		<activity
+			android:name=".SettingsActivity"
+			android:configChanges="orientation|locale|keyboard|keyboardHidden|navigation"
+			>
+		</activity>
+		<provider
+			android:name=".database.TheGamesDB"
+			android:authorities="virtualapplications.play.gamesdb" />
+		<activity
+            android:name=".ExternalEmulatorLauncher"
+            android:enabled="true"
+            android:exported="true"
+            android:label="@string/external_launcher">
 			<intent-filter>
 				<action android:name="android.intent.action.VIEW" />
 				
@@ -73,20 +93,6 @@
 					android:pathPattern=".*\\.elf"
 					android:scheme="file" />
 			</intent-filter>
-		</activity>
-		<activity
-			android:name=".EmulatorActivity"
-			android:configChanges="orientation|locale|keyboard|keyboardHidden|navigation"
-			android:screenOrientation="sensorLandscape"
-			android:theme="@android:style/Theme.NoTitleBar.Fullscreen">
-		</activity>
-		<activity
-			android:name=".SettingsActivity"
-			android:configChanges="orientation|locale|keyboard|keyboardHidden|navigation"
-			>
-		</activity>
-		<provider
-			android:name=".database.TheGamesDB"
-			android:authorities="virtualapplications.play.gamesdb" />
+        </activity>
 	</application>
 </manifest> 

--- a/build_android/project.properties
+++ b/build_android/project.properties
@@ -11,5 +11,5 @@
 #proguard.config=${sdk.dir}/tools/proguard/proguard-android.txt:proguard-project.txt
 
 # Project target.
-target=android-22
+target=android-21
 android.library.reference.1=../../appcompat

--- a/build_android/res/layout/fragment_all_games.xml
+++ b/build_android/res/layout/fragment_all_games.xml
@@ -1,0 +1,31 @@
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools" android:layout_width="match_parent"
+    android:layout_height="match_parent" tools:context="com.virtualapplications.play.all_games">
+
+    <LinearLayout
+        android:orientation="vertical"
+        android:layout_width="fill_parent"
+        android:layout_height="fill_parent">
+
+        <ScrollView
+            android:id="@+id/game_scroller"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_weight="1"
+            android:scrollbars="none"
+            android:fillViewport="true" >
+
+            <TableLayout
+                android:id="@+id/game_grid"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="10dp"
+                android:paddingBottom="10dp"
+                android:stretchColumns="*" >
+
+                <requestFocus />
+            </TableLayout>
+        </ScrollView>
+    </LinearLayout>
+
+</FrameLayout>

--- a/build_android/res/layout/fragment_all_games.xml
+++ b/build_android/res/layout/fragment_all_games.xml
@@ -6,26 +6,17 @@
         android:orientation="vertical"
         android:layout_width="fill_parent"
         android:layout_height="fill_parent">
-
-        <ScrollView
-            android:id="@+id/game_scroller"
+        <GridView xmlns:android="http://schemas.android.com/apk/res/android"
+            android:id="@+id/gridview"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:layout_weight="1"
-            android:scrollbars="none"
-            android:fillViewport="true" >
-
-            <TableLayout
-                android:id="@+id/game_grid"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="10dp"
-                android:paddingBottom="10dp"
-                android:stretchColumns="*" >
-
-                <requestFocus />
-            </TableLayout>
-        </ScrollView>
+            android:columnWidth="90dp"
+            android:numColumns="auto_fit"
+            android:verticalSpacing="10dp"
+            android:horizontalSpacing="10dp"
+            android:stretchMode="columnWidth"
+            android:gravity="center"
+            />
     </LinearLayout>
 
 </FrameLayout>

--- a/build_android/res/layout/main.xml
+++ b/build_android/res/layout/main.xml
@@ -33,30 +33,10 @@
 			android:layout_width="match_parent"
 			android:layout_height="match_parent" >
 			<LinearLayout
-				android:orientation="vertical"
-				android:layout_width="fill_parent"
-				android:layout_height="fill_parent">
-
-				<ScrollView
-					android:id="@+id/game_scroller"
-					android:layout_width="match_parent"
-					android:layout_height="match_parent"
-					android:layout_weight="1"
-					android:scrollbars="none"
-					android:fillViewport="true" >
-
-					<TableLayout
-						android:id="@+id/game_grid"
-						android:layout_width="match_parent"
-						android:layout_height="wrap_content"
-						android:layout_marginTop="10dp"
-						android:paddingBottom="10dp"
-						android:stretchColumns="*" >
-
-						<requestFocus />
-					</TableLayout>
-				</ScrollView>
-			</LinearLayout>
+				android:id="@+id/container"
+				android:layout_width="match_parent"
+				android:layout_height="match_parent"
+				android:orientation="horizontal" />
 		</FrameLayout>
 		<!-- The navigation drawer -->
 		<fragment android:id="@+id/navigation_drawer"

--- a/build_android/res/values/strings.xml
+++ b/build_android/res/values/strings.xml
@@ -28,4 +28,6 @@
     <string name="navigation_drawer_open">Open navigation drawer</string>
     <string name="navigation_drawer_close">Close navigation drawer</string>
 	<string name="pressback_exit">Please click BACK again to exit</string>
+
+    <string name="external_launcher">PLAY - PS2 Game Launcher</string>
 </resources>

--- a/build_android/res/values/styles.xml
+++ b/build_android/res/values/styles.xml
@@ -16,7 +16,7 @@
 
     <style name="Settings" parent="Theme.AppCompat.NoActionBar">
         <item name="android:windowTranslucentStatus">true</item>
-        <item name="android:windowTranslucentNavigation">false</item>
+        <item name="android:windowTranslucentNavigation">true</item>
         <!-- Customize your theme here. -->
         <!-- colorPrimary is used for the default action bar background -->
         <item name="colorPrimary">@color/action_bar_Blue</item>


### PR DESCRIPTION
changes
1) moved to fragments
--as such code has to be rearranged, so that fragment specific functions are in the proper class
2) moved External Intent Support (allowing external launcher) into own Class/Activity
--Just much cleaner code, instead of throwing everything into MainActivity
3) swapped to gridview for cover/game display (really rough work, as POC as it stands)
--note currently lacks all function, it works for display only
--column are auto created based on dpi, thus will always fill the screen horizontally, currently though cover sizes are hard-coded, this need to be fix to adjust to dpi.
as it stand this conflicts with LoungeKatt latest implementation for sorting out the list, since fragments wont be needed at all like that, so need to weight if they're still worth while including.

Not published:
Grid view, using adapter to manage cover view. 
It will auto adjust column to make maximum use of screen size on different devices with different pixel densities. 